### PR TITLE
Migrating from master-slave vocabulary

### DIFF
--- a/service.go
+++ b/service.go
@@ -97,5 +97,5 @@ func main() {
 	
 	crowService.CheckAllEggs()	//call this right away, as the ticker will fire it in 1 minute
 	
-	wg.Wait()	//wait for the slave and possible master to finish
+	wg.Wait()	//wait for the subordinate and possible main to finish
 }


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.